### PR TITLE
Add feature: Add Skip Param Documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aws_service_mcp_generator"
-version = "1.0.3"
+version = "1.0.4"
 description = "A Python class that generates MCP server for any AWS service which has boto3 client"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 
 [[package]]
@@ -27,7 +28,7 @@ wheels = [
 
 [[package]]
 name = "aws-service-mcp-generator"
-version = "1.0.0"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Param Documentation is too large. See https://github.com/kenliao94/aws_service_mcp_generator/issues/2

Adding a skip param documentation parameter for now that will allow you to skip the addition of all parameters