### PR TITLE
Add feature: Remove default values for Optional parameters

### DIFF
--- a/aws_service_mcp_generator/generator.py
+++ b/aws_service_mcp_generator/generator.py
@@ -122,12 +122,6 @@ class AWSToolGenerator:
             "integer": int,
             "map": dict[Any, Any],
         }
-        type_default = {
-            "string": str(),
-            "boolean": bool(),
-            "integer": 10,
-            "map": dict(),
-        }
         try:
             input_parameters = self.__get_operation_input_parameters(operation)
             for param_tuple in input_parameters:
@@ -153,7 +147,7 @@ class AWSToolGenerator:
                                 type_conversion.get(param_type, str),
                                 Field(description=param_documentation),
                             ],
-                            default=type_default.get(param_type, str()),
+                            default=None,
                         )
                     )
             # Add region to dynamically change region such that one MCP server can interact with multiple region

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aws_service_mcp_generator"
-version = "1.0.6"
+version = "2.0.0"
 description = "A Python class that generates MCP server for any AWS service which has boto3 client"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -28,7 +28,7 @@ wheels = [
 
 [[package]]
 name = "aws-service-mcp-generator"
-version = "1.0.5"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Changing Default Value to None, so that service does not receive a default value for non required fields

Issue: https://github.com/kenliao94/aws_service_mcp_generator/issues/4